### PR TITLE
Modified aggregator to verify file version before aggregation.

### DIFF
--- a/ColomaAnalysis/Program.cs
+++ b/ColomaAnalysis/Program.cs
@@ -13,10 +13,10 @@ namespace ColomaAnalysis
             string targetVersion = "1.0.0.1";
 
             // Configure this to output to the correct Analysis directory,
-            // NOTE: This will destroy other dataset.tsv files by default.
+            // NOTE: This will destroy dataset.tsv in the same directory if it exists.
             string filepath = @"\\iefs\users\mattgr\Coloma\Analysis";
 
-            // Configure this to point to the directly containing all the TSV files needing to be aggregated.
+            // Configure this to point to the directory containing all the TSV files needing to be aggregated.
             string folderPath = @"\\iefs\users\mattgr\Coloma\";
 
             DateTime start = DateTime.Now;

--- a/ColomaAnalysis/Program.cs
+++ b/ColomaAnalysis/Program.cs
@@ -1,11 +1,11 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 
 namespace ColomaAnalysis
 {
     class Program
-    { 
+    {
         static void Main(string[] args)
         {
             // Configure this so that only TSVs from our current data schema version are aggregated


### PR DESCRIPTION
Previously, end users running an outdated Coloma.exe could introduce malformed rows into the final aggregated product since an old Coloma.exe could produce a TSV with less columns.

This change adds "targetVersion" which is checked against a source TSV's filename before attempting to pull in a specific TSV.

Should it fail, the file will be skipped.
